### PR TITLE
Replace CBHC and Haxchi downloads with the ones from the appstore

### DIFF
--- a/docs/user-guide/cbhc/sd-preparation.md
+++ b/docs/user-guide/cbhc/sd-preparation.md
@@ -9,7 +9,6 @@ We will now place the required CFW files and some additional homebrew files on t
 
 ### What You Need {docsify-ignore}
 
-- The Haxchi <a href="docs/files/config.txt" download>config</a>.
 - The latest release of [Homebrew Launcher Installer](https://github.com/wiiu-env/homebrew_launcher_installer/releases/latest).
   - You will need to download the `payload.zip` file.
 - The 1.4 release of [The Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/1.4).
@@ -20,8 +19,8 @@ We will now place the required CFW files and some additional homebrew files on t
 - The latest release of [Wii U NAND Dumper](https://github.com/koolkdev/wiiu-nanddumper/releases/latest).
 - The latest release of the [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest).
   - You will need to download the `wiiu-extracttosd.zip` file.
-- The latest release of [Haxchi and CBHC](https://github.com/FIX94/haxchi/releases/latest).
-  - Download both the Haxchi and CBHC .zip files.
+- The latest release of [Haxchi](https://www.wiiubru.com/appstore/zips/haxchi.zip).
+- The latest release of [CBHC](https://www.wiiubru.com/appstore/zips/cbhc.zip).
 - The latest release of <a href="docs/files/SaveMii_Mod.zip" download>SaveMii Mod</a>.
 
 ### Instructions {docsify-ignore}
@@ -32,12 +31,11 @@ We will now place the required CFW files and some additional homebrew files on t
 1. Insert your Wii U's SD Card into your PC.
 1. Create a folder called `install` on the root of your SD Card.
 1. Extract the `homebrew_launcher_channel.v2.1_fix.zip` file to the `install` folder you created.
-1. Extract the `Haxchi.zip` file to the root of your SD Card.
-1. Extract the `CBHC.zip` file to the root of your SD Card.
+1. Extract the `haxchi.zip` file to the root of your SD Card.
+1. Extract the `cbhc.zip` file to the root of your SD Card.
 1. Extract the `wup_installer_gx2.zip` file to the root of your SD Card.
 1. Extract the `nanddumper.zip` file to the root of your SD Card.
 1. Extract the `wiiu-extracttosd.zip` file to the root of your SD Card.
 1. Extract the `homebrew_launcher.v.1.4.zip` file to the root of your SD Card.
 1. Extract the `savemii_mod.zip` file to the root of your SD Card.
-1. Copy the `config.txt` file to the `haxchi` folder on the root of your SD Card. Overwrite files if asked.
 1. Copy the `payload.elf` from the `payload.zip` to the `wiiu` folder on your SD Card.

--- a/docs/user-guide/haxchi/sd-preparation.md
+++ b/docs/user-guide/haxchi/sd-preparation.md
@@ -9,7 +9,6 @@ We will now place the required CFW files and some additional homebrew files on t
 
 ### What You Need {docsify-ignore}
 
-- The Haxchi <a href="docs/files/config.txt" download>config</a>
 - The latest release of [Homebrew Launcher Installer](https://github.com/wiiu-env/homebrew_launcher_installer/releases/latest).
   - You will need to download the `payload.zip` file.
 - The 1.4 release of [The Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/1.4).
@@ -20,8 +19,7 @@ We will now place the required CFW files and some additional homebrew files on t
 - The latest release of [Wii U NAND Dumper](https://github.com/koolkdev/wiiu-nanddumper/releases/latest).
 - The latest release of the [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest).
   - You will need to download the `wiiu-extracttosd.zip` file.
-- The latest release of [Haxchi](https://github.com/FIX94/haxchi/releases/latest).
-  - Download only the Haxchi `.zip` file.
+- The latest release of [Haxchi](https://www.wiiubru.com/appstore/zips/haxchi.zip).
 - The latest release of <a href="docs/files/SaveMii_Mod.zip" download>SaveMii Mod</a>.
 
 ### Instructions {docsify-ignore}
@@ -32,11 +30,10 @@ We will now place the required CFW files and some additional homebrew files on t
 1. Insert your Wii U's SD Card into your PC.
 1. Create a folder called `install` on the root of your SD Card.
 1. Extract the `homebrew_launcher_channel.v2.1_fix.zip` file to the `install` folder you created.
-1. Extract the `Haxchi.zip` file to the root of your SD Card.
+1. Extract the `haxchi.zip` file to the root of your SD Card.
 1. Extract the `wup_installer_gx2.zip` file to the root of your SD Card.
 1. Extract the `nanddumper.zip` file to the root of your SD Card.
 1. Extract the `wiiu-extracttosd.zip` file to the root of your SD Card.
 1. Extract the `homebrew_launcher.v.1.4.zip` file to the root of your SD Card.
 1. Extract the `savemii_mod.zip` file to the root of your SD Card.
-1. Copy the `config.txt` file to the `haxchi` folder on the root of your SD Card. Overwrite files if asked.
 1. Copy the `payload.elf` from the `payload.zip` to the `wiiu` folder on your SD Card.


### PR DESCRIPTION
- Skips the need for downloading and replacing the config file
- The appstore will no longer prompt the user to update