### PR TITLE
Default to preferred color scheme

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -1,5 +1,5 @@
-@import url("light.css");
-@import url("dark.css") (prefers-color-scheme: dark);
+@import url("dark.css");
+@import url("light.css") (prefers-color-scheme: light);
 
 .markdown-section iframe[src*="buttons.github.io"] {
     margin: 0;

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -1,3 +1,6 @@
+@import url("light.css");
+@import url("dark.css") (prefers-color-scheme: dark);
+
 .markdown-section iframe[src*="buttons.github.io"] {
     margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
     <link rel="icon" href="docs/assets/img/favicon.ico">
 
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="docs/assets/css/dark.css" title="Dark">
     <link rel="stylesheet" href="docs/assets/css/main.css">
 
     <!-- Alternate Stylesheets -->
-    <link rel="stylesheet alternate" href="docs/assets/css/light.css" title="Light">
+    <link rel="stylesheet" href="docs/assets/css/dark.css" title="Dark" disabled>
+    <link rel="stylesheet" href="docs/assets/css/light.css" title="Light" disabled>
 </head>
 
 <body>


### PR DESCRIPTION
This changes the CSS loading so that it will default to the device's preferred color scheme instead of always dark, with light as the fallback for older computers. Though if you'd like I can change it to fallback to dark, all you need to do is swap the imports to:
```css
@import url("dark.css");
@import url("light.css") (prefers-color-scheme: light);
```

The color scheme dropdown still works exactly as it did before.

Apologies if this somehow breaks something or so, it's a very simple change though 😅 

---

Tested on the latest Safari, Edge, and Firefox on macOS 10.14, Leopard Webkit and TenFourFox on Mac OS X 10.5, and some probably outdated version of Bromite on Android 5