### PR TITLE
Add a couple notices in vWii guide to clarify FAQs

### DIFF
--- a/docs/vwii/vwii-modding.md
+++ b/docs/vwii/vwii-modding.md
@@ -7,7 +7,7 @@ We will now place the required Homebrew files on the SD Card.
 ?> **Notice**
     Your SD Card will need to be formatted as FAT32. If your SD Card is not formatted to FAT32, use [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) with 32k (32768) Allocation unit size to format it. **Do not** label the SD Card as `wiiu` or it will cause issues with homebrew.
     
-?> If you have modded your Wii U in the past, you can use the same SD Card for this process.
+?> If you have hacked your Wii U in the past, you can use the same SD Card for this process.
     
     
 

--- a/docs/vwii/vwii-modding.md
+++ b/docs/vwii/vwii-modding.md
@@ -6,6 +6,10 @@ We will now place the required Homebrew files on the SD Card.
 
 ?> **Notice**
     Your SD Card will need to be formatted as FAT32. If your SD Card is not formatted to FAT32, use [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) with 32k (32768) Allocation unit size to format it. **Do not** label the SD Card as `wiiu` or it will cause issues with homebrew.
+    
+?> If you have modded your Wii U in the past, you can use the same SD Card for this process.
+    
+    
 
 ### What You Need {docsify-ignore}
 
@@ -30,6 +34,8 @@ We will now place the required Homebrew files on the SD Card.
 ### NAND Backup
 
 In case anything goes wrong in the later process and your vWii ends up bricked, restoring a previously made NAND backup can fix it.
+
+?> If you have recently made a NAND backup that includes SLCCMPT and OTP, feel free to skip this step.
 
 1. Launch the [Homebrew Launcher](vwii/browser-exploit).
 1. Launch the `Wii U NAND Dumper` application.


### PR DESCRIPTION
Adds a couple notices to the vWii guide to clarify frequently asked questions in assistance channels.

start of the guide: "If you have hacked your Wii U in the past, you can use the same SD Card for this process."

NAND backup section: "If you have recently made a NAND backup that includes SLCCMPT and OTP, feel free to skip this step."

the wording of the second notice could be improved imo, but I'll create this for some feedback