### PR TITLE
Update sd-preparation.md

### DIFF
--- a/docs/extras/block-updates.md
+++ b/docs/extras/block-updates.md
@@ -24,7 +24,7 @@ Currently, two ways exist to block updates on the Wii U system:
 
 ### DNS Blocking
 
-?> This method is the easier method and is recommended to less advanced users. It does, however, prevent the eShop from working. This can be worked around by running [NNUPatcher](https://www.wiiubru.com/appstore/zips/nnupatcher.zip) before starting the eShop.
+?> This method is the easier method and is recommended to less advanced users. It does, however, prevent the eShop from working. This can be worked around by running [NNUPatcher](https://wiiubru.com/appstore/zips/nnupatcher.zip) before starting the eShop.
 1. Plug your SD Card into your Computer.
 1. Copy the contents of the `nnupatcher.zip` file to the root of your SD Card. If asked, overwrite any duplicate files.
 1. Plug the SD Card into your Wii U console and power it on.

--- a/docs/extras/dump-games.md
+++ b/docs/extras/dump-games.md
@@ -21,7 +21,7 @@ If you intend to use this guide to share your dumped games, don't.
 
 - Your SD Card needs to have enough space to fit the game you want to dump.
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip).
-- The [disc2app](https://www.wiiubru.com/appstore/zips/disc2app.zip) homebrew application.
+- The [disc2app](https://wiiubru.com/appstore/zips/disc2app.zip) homebrew application.
 
 ### Instructions {docsify-ignore}
 
@@ -55,7 +55,7 @@ If you intend to use this guide to share your dumped games, don't.
 - Your SD Card needs to have enough space to fit the game you want to dump.
 - A USB HDD (+ a Y-cable if needed)
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
-- The [disc2app](https://www.wiiubru.com/appstore/zips/disc2app.zip) Homebrew app
+- The [disc2app](https://wiiubru.com/appstore/zips/disc2app.zip) Homebrew app
 
 ### Instructions {docsify-ignore}
 
@@ -88,8 +88,8 @@ If you intend to use this guide to share your dumped games, don't.
 
 - A USB storage device (+a Y-cable if needed) with enough space to fit the game you want to dump.
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
-- The [disc2app](https://www.wiiubru.com/appstore/zips/disc2app.zip) Homebrew app.
-- The [MochaFAT32](https://www.wiiubru.com/appstore/zips/mocha_fat32.zip) Homebrew app.
+- The [disc2app](https://wiiubru.com/appstore/zips/disc2app.zip) Homebrew app.
+- The [MochaFAT32](https://wiiubru.com/appstore/zips/mocha_fat32.zip) Homebrew app.
 - The  1.4 release of [The Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/1.4)
   - You will need to download the v1.4 `homebrew_launcher.v.1.4.zip` release.
 

--- a/docs/user-guide/cbhc/sd-preparation.md
+++ b/docs/user-guide/cbhc/sd-preparation.md
@@ -16,11 +16,11 @@ We will now place the required CFW files and some additional homebrew files on t
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip).
 - The latest release of [The Homebrew Launcher Channel](https://github.com/GaryOderNichts/homebrew_launcher/releases/tag/v2.1_fix).
   - You will need to download the `homebrew_launcher_channel.v2.1_fix.zip` file.
-- The latest release of [Wii U NAND Dumper](https://www.wiiubru.com/appstore/zips/nanddumper.zip).
+- The latest release of [Wii U NAND Dumper](https://wiiubru.com/appstore/zips/nanddumper.zip).
 - The latest release of the [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest).
   - You will need to download the `wiiu-extracttosd.zip` file.
-- The latest release of [Haxchi](https://www.wiiubru.com/appstore/zips/haxchi.zip).
-- The latest release of [CBHC](https://www.wiiubru.com/appstore/zips/cbhc.zip).
+- The latest release of [Haxchi](https://wiiubru.com/appstore/zips/haxchi.zip).
+- The latest release of [CBHC](https://wiiubru.com/appstore/zips/cbhc.zip).
 - The latest release of <a href="docs/files/SaveMii_Mod.zip" download>SaveMii Mod</a>.
 
 ### Instructions {docsify-ignore}

--- a/docs/user-guide/haxchi/sd-preparation.md
+++ b/docs/user-guide/haxchi/sd-preparation.md
@@ -16,10 +16,10 @@ We will now place the required CFW files and some additional homebrew files on t
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip).
 - The latest release of [The Homebrew Launcher Channel](https://github.com/GaryOderNichts/homebrew_launcher/releases/tag/v2.1_fix).
   - You will need to download the `homebrew_launcher_channel.v2.1_fix.zip` file.
-- The latest release of [Wii U NAND Dumper](https://www.wiiubru.com/appstore/zips/nanddumper.zip).
+- The latest release of [Wii U NAND Dumper](https://wiiubru.com/appstore/zips/nanddumper.zip).
 - The latest release of the [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest).
   - You will need to download the `wiiu-extracttosd.zip` file.
-- The latest release of [Haxchi](https://www.wiiubru.com/appstore/zips/haxchi.zip).
+- The latest release of [Haxchi](https://wiiubru.com/appstore/zips/haxchi.zip).
 - The latest release of <a href="docs/files/SaveMii_Mod.zip" download>SaveMii Mod</a>.
 
 ### Instructions {docsify-ignore}

--- a/docs/user-guide/mocha/indexiine/sd-preparation.md
+++ b/docs/user-guide/mocha/indexiine/sd-preparation.md
@@ -15,10 +15,10 @@ We will now place the required CFW files and some additional homebrew files on t
 - The 1.4 release of [The Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/1.4).
   - You will need to download the v1.4 `homebrew_launcher.v1.4.zip` release of The Homebrew Launcher.
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip).
-- The latest release of [Wii U NAND Dumper](https://www.wiiubru.com/appstore/zips/nanddumper.zip).
+- The latest release of [Wii U NAND Dumper](https://wiiubru.com/appstore/zips/nanddumper.zip).
 - The latest release of the [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest).
   - You will need to download the `wiiu-extracttosd.zip` file.
-- The latest release of [Mocha](https://www.wiiubru.com/appstore/zips/mocha.zip).
+- The latest release of [Mocha](https://wiiubru.com/appstore/zips/mocha.zip).
 - The latest release of <a href="docs/files/SaveMii_Mod.zip" download>SaveMii Mod</a>.
 - The latest release of [Indexiine-Installer](https://github.com/GaryOderNichts/indexiine-installer/releases/latest).
 

--- a/docs/user-guide/mocha/online-exploit/sd-preparation.md
+++ b/docs/user-guide/mocha/online-exploit/sd-preparation.md
@@ -15,10 +15,10 @@ We will now place the required CFW files and some additional homebrew files on t
 - The 1.4 release of [The Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/1.4).
   - You will need to download the v1.4 `homebrew_launcher.v1.4.zip` release of The Homebrew Launcher.
 - The latest release of [WUP Installer GX2](https://wiiubru.com/appstore/zips/wup_installer_gx2.zip).
-- The latest release of [Wii U NAND Dumper](https://www.wiiubru.com/appstore/zips/nanddumper.zip).
+- The latest release of [Wii U NAND Dumper](https://wiiubru.com/appstore/zips/nanddumper.zip).
 - The latest release of the [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest).
   - You will need to download the `wiiu-extracttosd.zip` file.
-- The latest release of [Mocha](https://www.wiiubru.com/appstore/zips/mocha.zip).
+- The latest release of [Mocha](https://wiiubru.com/appstore/zips/mocha.zip).
 - The latest release of <a href="docs/files/SaveMii_Mod.zip" download>SaveMii Mod</a>.
 
 ### Instructions {docsify-ignore}

--- a/docs/vwii/vwii-modding.md
+++ b/docs/vwii/vwii-modding.md
@@ -14,7 +14,7 @@ We will now place the required Homebrew files on the SD Card.
 ### What You Need {docsify-ignore}
 
 - The latest release of the [vwii-compat-installer](https://github.com/TheLordScruffy/vwii-compat-installer/releases).
-- The latest release of the [Wii U NAND Dumper](https://www.wiiubru.com/appstore/zips/nanddumper.zip).
+- The latest release of the [Wii U NAND Dumper](https://wiiubru.com/appstore/zips/nanddumper.zip).
 - The <a href="docs/files/Patched_IOS80_Installer_for_vWii.zip" download>Patched IOS 80 Installer for vWii</a>.
 - The <a href ="docs/files/d2x_cIOS_Installer.zip" download>d2x cIOS Installer</a>.
 - The [Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/download/1.4/homebrew_launcher.v1.4.zip).


### PR DESCRIPTION
Removed the www subdomain part of urls for appstore so that upon appstore's downtime the alternate server functions in an SSL env , maybe you can check the rest of your guide for relevant URLS ?