### PR TITLE
Make small part in introduction clearer

### DIFF
--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -54,7 +54,7 @@ If everything goes according to plan, you will lose no data and end up with ever
 
 Keep your device plugged in throughout the entire process to avoid data loss or damage from an unexpected power-off.
 
-After following this guide, CFW will be loaded and enabled on boot. Unless you choose to not autoboot PayloadLoader.
+After following this guide, CFW will be loaded and enabled on boot, unless you choose to not follow the Autobooting Tiramisu section.
 
 It is advised that you read the entire guide from start to finish one or more times before actually running through the guide with your system.
 


### PR DESCRIPTION
Slightly clarifies the “Unless you choose to not autoboot PayloadLoader” part. New version instead references the Autobooting Tiramisu section to make things clearer for the average user.

also wtf ~~gary~~ ~~noah~~ elpunical how could you put a full stop where a comma should be. this is heinous. I am calling the police right now and ~~german SWAT~~ french SWAT is on their way. you should feel bad

![2C3D5DC1-D757-4817-9489-CC0AB0177530](https://user-images.githubusercontent.com/53618962/147840483-b5e99409-f6c1-43b9-a8bb-7296853c7c6e.jpeg)
