### PR TITLE
Clarify B button requirement on Browser Exploit step

### DIFF
--- a/docs/user-guide/tiramisu/browser-exploit.md
+++ b/docs/user-guide/tiramisu/browser-exploit.md
@@ -8,6 +8,7 @@ Make sure your Wii U has internet access for this step.
 
 1. Take the SD Card out of your computer and plug it into your Wii U console.
 1. Launch the Internet Browser and navigate to the website `wiiuexploit.xyz`.
-1. Click on `Run Exploit!` and hold the B button until you see a menu, this will be necessary for the next steps.
+1. Click on `Run Exploit!` and **hold the B button** until you see a menu, this will be necessary for the next steps.
     - If your Wii U gets stuck on a white or otherwise frozen screen, wait a few seconds. If nothing happens, reboot the console, [reset the browser's save data](https://en-americas-support.nintendo.com/app/answers/detail/a_id/1507/~/how-to-delete-the-internet-browser-history) and try again.
-
+    - If you held the B button after clicking `Run Exploit!`, you should see a menu listing `default` and `nanddumper` as options. This is the menu required for the next step. 
+    - If you did not hold the B button after clicking `Run Exploit!`, you will see a menu listing `installer` and `tiramisu` as options. If you see this menu, reboot the console and try again.


### PR DESCRIPTION
It's easy to miss the "holding the B button" requirement as it is part of a compound sentence, so I made it bold and added clarifying bullet points telling the user what they should see if they successfully completed the step.