### PR TITLE
Update the update blocking steps

### DIFF
--- a/docs/extras/block-updates.md
+++ b/docs/extras/block-updates.md
@@ -2,16 +2,13 @@
 ---
 All currently known Wii U exploits can, unlike e.g. the Nintendo Switch RCM exploit, be patched by a system update. Although the Wii U is no longer officially supported, Nintendo may still release updates for it. Namely, the updates 5.5.3 up to 5.5.6 were all released after the Wii U was discontinued, so blocking updates is still a recommended action.
 
+While Tiramisu already has built-in update blocking functionality, it is recommended to delete the update folder to effectively block system updates.
+If you get a red warning screen while booting into Tiramisu, the update folder still exists and it is recommended to delete it using the guide below.
+
 ### Instructions {docsify-ignore}
 
-Currently, three ways exist to block updates on the Wii U system:
+Currently, two ways exist to effectively block updates on the Wii U system:
 <!-- tabs:start -->
-
-#### **Tiramisu Autoboot**
-
-### Tiramisu Autoboot
-
-?> When autobooting into the the PayloadLoader, updates are automatically blocked. To enable autobooting into the PayloadLoader follow [this](../docs/user-guide/tiramisu/autoboot).
 
 #### **Deleting Update Folder**
 

--- a/docs/extras/unblock-updates.md
+++ b/docs/extras/unblock-updates.md
@@ -2,6 +2,8 @@
 ---
 This is needed if you ever need to perform a System Update.
 
+?> If you are running Tiramisu and have deleted the update folder, you need to disable both autobooting and recreate the update folder.
+
 ### Instructions {docsify-ignore}
 
 <!-- tabs:start -->

--- a/docs/user-guide/tiramisu/finalizing-setup.md
+++ b/docs/user-guide/tiramisu/finalizing-setup.md
@@ -11,12 +11,17 @@ We are going to make the Tiramisu environment start automatically when your cons
 1. Turn on your Wii U.
     - The Environment Loader should show up.
 1. Using the D-Pad, navigate to `tiramisu` and press Y to set this to your default envrionment, then press A to launch into Tiramisu.
+    - You might get a red warning screen telling you that updates aren't blocked properly. Press A to continue anyways. We're going to block updates in the "Blocking Updates" section below.
     - To open the Environment Loader selector in the future, you have hold X while your Wii U is booting up.
 1. On the Tiramisu Boot Selector, the `Wii U Menu` should already be selected, press Y to set this to your default autobooting option, then press A to launch into the Wii U Menu.
     - To open the Tiramisu Boot Selector in the future, you have hold START (+) while your Wii U is booting up.
 
 ?> Once you're booted into the Tiramisu environment, you can open the Mii Maker at any time to get into the Homebrew Launcher.
 <br>To get back into the Mii Maker, simply press the HOME button while in the Homebrew Launcher.
+
+### Blocking Updates
+While Tiramisu already has built-in update blocking functionality, it is recommended to delete the update folder to effectively block system updates.
+If you get a red warning screen while booting into Tiramisu, the update folder still exists and it is recommended to delete it using [this guide](../block-updates).
 
 ### Additional Homebrew Apps
 

--- a/docs/user-guide/tiramisu/installing-payloadloader.md
+++ b/docs/user-guide/tiramisu/installing-payloadloader.md
@@ -21,4 +21,4 @@ Installing the PayloadLoader will let you access Tiramisu just by running the He
 1. You'll be asked if you are sure you want to install the PayloadLoader. Use the D-Pad to select `Install` and press A.
 1. After installing finishes, press A to shut down the console.
 
-!> If you do not wish to autoboot Tiramisu on your console, you can skip the `Autobooting Tiramisu` part. </br> But you need to be aware that system updates won't be blocked and will need to be blocked by following [this guide](../block-updates). This is not required but it's highly recommended.
+!> If you do not wish to autoboot Tiramisu on your console, you can skip the `Autobooting Tiramisu` part and head directly to [Finalizing Setup](finalizing-setup).


### PR DESCRIPTION
Since Tiramisu's update blocks aren't effective while in standby mode, this updates the guide to recommend deleting the update folder.
Also adds a note regarding the warning screen added in https://github.com/wiiu-env/AutobootModule/pull/15.