### PR TITLE
Specify what has the update-blocking functionality

### DIFF
--- a/docs/extras/block-updates.md
+++ b/docs/extras/block-updates.md
@@ -2,7 +2,7 @@
 ---
 All currently known Wii U exploits can, unlike e.g. the Nintendo Switch RCM exploit, be patched by a system update. Although the Wii U is no longer officially supported, Nintendo may still release updates for it. Namely, the updates 5.5.3 up to 5.5.6 were all released after the Wii U was discontinued, so blocking updates is still a recommended action.
 
-While Tiramisu already has built-in update blocking functionality, it is recommended to delete the update folder to effectively block system updates.
+While Tiramisu's PayloadLoader already has built-in update blocking functionality, it is recommended to delete the update folder to effectively block system updates.
 If you get a red warning screen while booting into Tiramisu, the update folder still exists and it is recommended to delete it using the guide below.
 
 ### Instructions {docsify-ignore}

--- a/docs/user-guide/tiramisu/finalizing-setup.md
+++ b/docs/user-guide/tiramisu/finalizing-setup.md
@@ -20,7 +20,7 @@ We are going to make the Tiramisu environment start automatically when your cons
 <br>To get back into the Mii Maker, simply press the HOME button while in the Homebrew Launcher.
 
 ### Blocking Updates
-While Tiramisu already has built-in update blocking functionality, it is recommended to delete the update folder to effectively block system updates.
+While Tiramisu's PayloadLoader already has built-in update blocking functionality, it is recommended to delete the update folder to effectively block system updates.
 If you get a red warning screen while booting into Tiramisu, the update folder still exists and it is recommended to delete it using [this guide](../block-updates).
 
 ### Additional Homebrew Apps


### PR DESCRIPTION
This should be more clear that the PayloadLoader is what handles update blocking rather than Tiramisu/Aroma/future environments, which would help users understand why disabling autoboot is required to update.