### PR TITLE
Slightly improve grammar in Common Issues & Fixes

### DIFF
--- a/docs/troubleshooting/common-issues-fixes.md
+++ b/docs/troubleshooting/common-issues-fixes.md
@@ -2,7 +2,7 @@
 ---
 ### Haxchi common errors
 
- - **-3:** No SD Card detected. Re-insert the SD Card and try again. Make sure the SD Card is in FAT32 format. If the error persists, try blowing into the SD slot as it can get dusty inside.
+ - **-3:** No SD Card detected. Re-insert the SD Card and try again. Make sure the SD Card is in FAT32 format and there is no dust in the SD slot.
 
  - **-4:** SD detected but could not mount. Check to see if the SD is using MBR and not GPT. Also, check to see if there are any other partitions on the SD Card and merge them into one primary partition.
 
@@ -10,7 +10,7 @@
 
 ### Browser errors
 
- - **FSGetMountSource failed:** Same as -3 above, means no SD Card detected. Re-insert the SD and try again.
+ - **FSGetMountSource failed:** Same as -3 above, means no SD Card detected. Re-insert the SD and try again. Make sure the SD Card is in FAT32 format and there is no dust in the SD slot.
 
  - **FSOpenFile failed [...] payload.elf:** Missing payload file on SD. Make sure you have payload.elf in the wiiu folder.
 
@@ -19,8 +19,11 @@
 ### Data Management asks to delete unnecessary data, what does it mean?
 
 This refers to leftover files from incomplete installs. Always choose Yes to delete this data, as it takes up space for no good reason.
-If it ever stays stuck on deleting the data in an infinite loop, you can manually delete the data yourself.  
-Use FTPiiU Everywhere and browse to `/storage_mlc/usr/import` then delete any files in the folder if any exists. This is where the partial installs exist after incomplete installs. It'll be `/storage_usb/usr/import` if installed to a USB.  
+
+If it ever stays stuck on deleting the data in an infinite loop, you can manually delete the data yourself.
+
+Use FTPiiU Everywhere and browse to `/storage_mlc/usr/import` then delete any files in the folder if any exists. This is where the partial installs exist after incomplete installs. It'll be `/storage_usb/usr/import` if installed to a USB.
+
 The `import` folder should always be kept empty.
 
 ### My HDD doesn't work or makes a weird clicking sound, what should I do?


### PR DESCRIPTION
Also remove the bit about blowing into SD slot, as that can introduce moisture and therefore rust! Having said that, maybe the entire "Haxchi common errors" section could be removed, now that Haxchi is no longer recommended?

Also, the "info.json & manifest.install" section is also in the FAQ. Should it be removed from here (or removed from FAQ)?