### PR TITLE
Add initial Aroma guide

### DIFF
--- a/docs/extras/block-updates.md
+++ b/docs/extras/block-updates.md
@@ -17,7 +17,7 @@ Currently, two ways exist to effectively block updates on the Wii U system:
 ?> This method of update blocking is a bit more advanced than DNS Blocking and uses a homebrew app to modify system files. However, it has the advantage that the eShop's functionality will not be restricted.
 1. Plug your SD Card into your Computer.
 1. Download and extract [UFDiine](https://github.com/GaryOderNichts/UFDiine/releases/tag/v1.1) to the root of your SD Card.
-1. Plug the SD Card into your Wii U console and power it on.
+1. Plug the SD Card into your Wii U console and boot Tiramisu.
 1. Enter the Homebrew Launcher.
 1. Navigate the Homebrew Launcher and run the UFDiine app.
 1. Press the A button to delete the update folder.

--- a/docs/extras/dump-games.md
+++ b/docs/extras/dump-games.md
@@ -27,7 +27,7 @@ If you intend to use this guide to share your dumped games, don't.
 1. Copy the contents of the `wup_installer_gx2.zip` file to the root of your SD Card.
 1. Copy the contents of the newly downloaded wudd `.zip` file to the root of your SD Card.
 1. Take the SD Card out of your PC and insert it into your Wii U.
-1. Power on your Wii U.
+1. Power on your Wii U and boot into Tiramisu.
 1. Launch the Homebrew Launcher and start the wudd app.
 1. Change dump location to the SD Card.
 1. Select `Dump partition as .app`

--- a/docs/user-guide/aroma/finalizing-setup.md
+++ b/docs/user-guide/aroma/finalizing-setup.md
@@ -1,0 +1,46 @@
+# Aroma {docsify-ignore-all}
+
+## Finalizing Setup
+
+Now that Aroma is on your SD Card, we need to set up some final things.
+
+### Booting into Aroma
+
+1. Take the SD Card out of your computer and plug it into your Wii U console.
+1. Start the EnvironmentLoader.
+    - If you're autobooting into Tiramisu, this can be done by powering on your console and holding `X`.
+1. Highlight the entry called `aroma` using the D-Pad.  
+    - To make the console autoboot Aroma press `Y`.
+1. Launch Aroma by pressing `A`.
+    - If you get a red warning screen telling you that updates aren't blocked properly, you might want to block updates by following [this guide](../block-updates).
+1. On the Boot Selector, the `Wii U Menu` should already be selected, press Y to set this to your default autobooting option, then press A to launch into the Wii U Menu.
+    - To open the Boot Selector in the future, you have hold START (+) while launching Aroma.
+
+You are now running Aroma. Any apps you have on your SD Card will show up on the Wii U menu.
+
+?> **Aroma does not support the Homebrew Launcher**  
+Launch apps from the Wii U menu using the `homebrew_on_menu` plugin.
+
+You can now open the Plugin Configuration Menu using `L + Down + SELECT (-)` on the GamePad or Pro Controller (or `B + Down + Minus (-)` for WiiMotes).
+
+### Installing apps, modules, and plugins
+
+Base-Aroma already comes with several useful plugins and modules.  
+You can also install additional Aroma compatible apps, modules and plugins. Below is a list with various recommendations.
+
+| Name | Description | Installation Instructions |
+| ---- | ----------- | ------------ |
+| [FTPiiU Plugin](https://github.com/wiiu-env/ftpiiu_plugin/) ([Download](https://github.com/wiiu-env/ftpiiu_plugin/releases)) | Runs a FTP server in the background. | 1. Extract the downloaded `ftpiiu_vX_X.zip` file. <br> 2. Copy the `ftpiiu.wps` to the `wiiu/environments/aroma/plugins` folder on the root of your SD Card. |
+| [SDCafiine](https://github.com/wiiu-env/sdcafiine_plugin/) ([Download](https://github.com/wiiu-env/sdcafiine_plugin/releases)) | Allows you to mod games by redirecting files to the SD card. | 1. Extract the downloaded `sdcafiine_vX_X_X.zip` file. <br> 2. Copy the `sdcafiine.wps` to the `wiiu/environments/aroma/plugins` folder on the root of your SD Card. |
+| [Bloopair](https://github.com/GaryOderNichts/Bloopair/) ([Download](https://github.com/GaryOderNichts/Bloopair/releases)) | Allows wirelessly connecting most popular Bluetooth capable controllers. | 1. Extract the contents of the newly downloaded `Bloopair_vX.X.X.zip` file. <br> 2. Copy the `30_bloopair.rpx` to the `wiiu/environments/aroma/modules/setup/` folder on the root of your SD Card. <br> 3. Copy the `wiiu` folder to the root of your SD Card. |
+
+### Booting into Tiramisu
+
+If you find the need to boot into Tiramisu, for example, due to a homebrew app not supported by Aroma, simply do the following:
+
+1. Take the SD Card out of your computer and plug it into your Wii U console.
+1. Start the EnvironmentLoader.
+    - If you're autobooting into it, this can be done by powering on your console and holding `X`.
+1. Highlight the entry called `tiramisu` using the D-Pad.  
+    - To make the console autoboot Tiramisu press `Y`.
+1. Launch Tiramisu by pressing `A`.

--- a/docs/user-guide/aroma/getting-started.md
+++ b/docs/user-guide/aroma/getting-started.md
@@ -1,0 +1,50 @@
+# Aroma {docsify-ignore-all}
+
+Aroma is a work-in-progress environment and a possible successor for Tiramisu.
+
+!> **Aroma is currently in beta and still experimental!**  
+Expect potential issues and make sure to report them, if you encounter any.  
+If you still want to proceed, make sure to fully read this page.
+
+?> This guide will not remove Tiramisu. After following this guide you can still choose to boot into Tiramisu.
+
+### What is Aroma?
+
+Aroma is an environment like Tiramisu, which can be booted through the Environment Loader.  
+Aroma, just like Tiramisu, uses the same Mocha version, support for setup modules, and comes with the Autoboot Module, which includes the boot selector and Quick Start support.  
+Aroma comes with several additional features, including a plugin system and a new way of launching homebrews.
+
+### What can I do with Aroma?
+
+For a detailed overview check out [this blogpost](https://maschell.github.io/homebrew/2022/09/05/aroma.html). A quick summary is given below.
+
+#### Modules
+
+Aroma supports modules, which unlike setup modules, always run in the background.  
+This allows further extending the functionality of the console.
+
+#### Plugins
+
+Plugins, similarly to modules, are also running in the background.  
+They can enhance the experience of the console by changing and providing additional features.  
+Plugins can be configured using a configuration menu, which can be opened using a button combination.
+
+#### Wii U Homebrew Bundles
+
+Wii U Homebrew Bundles (WUHB) are a new way of launching homebrew.  
+These `.wuhb` files contain the main executable and can directly include icon and banner images and additional content.  
+With the `homebrew_on_menu` plugin, WUHB files can be directly launched from the Wii U menu, just like official channels.
+
+### What are the limitations?
+
+Due to technical limitations, a lot of old homebrew applications will no longer work with Aroma.  
+This includes all `.elf` homebrews, but also some `.rpx` homebrews, which don't implement necessary functionality properly.  
+These homebrews need to be updated with support for Aroma. To run old homebrews you need to boot the Tiramisu environment.  
+Launching homebrews through the now outdated Homebrew Launcher is no longer possible with Aroma.  
+
+Besides the limitations mentioned above, note that Aroma is still a beta release. Not everything has been tested yet, and additional issues might be discovered.  
+
+### Getting started
+
+Before continuing to the next page, make sure to install the PayloadLoader.  
+This can be done by following the [Tiramisu guide](../tiramisu/sd-preparation).

--- a/docs/user-guide/aroma/sd-preparation.md
+++ b/docs/user-guide/aroma/sd-preparation.md
@@ -1,0 +1,24 @@
+# Aroma {docsify-ignore-all}
+
+## SD Preparation
+
+We will now place the required CFW files and some additional homebrew files on the SD Card.
+
+?> **Notice**
+    Your SD Card will need to be formatted as FAT32. If your SD Card is not formatted to FAT32, use [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) with 32k (32768) allocation unit size to format it.  
+    **Do not** label the SD Card as `wiiu` or it will cause issues with homebrew.
+
+### What You Need
+
+- The latest files from the [Aroma download page](https://aroma.foryour.cafe).
+    1. Scroll down to the **Download** section.
+    1. Read through the steps and click on the checkboxes.
+    1. Click on `Download Payloads` and `Download Base Aroma`.
+
+### Instructions
+
+1. Insert your Wii U's SD Card into your PC.
+1. **Extract** and copy the `wiiu` folder of the two newly downloaded *`.zip`* files to the root of your SD Card.
+    - The two `wiiu` folders should be merged if not done automatically.
+
+?> If your computer asks you to overwrite existing files on your SD Card, you will need to click yes.

--- a/docs/user-guide/aroma/sd-preparation.md
+++ b/docs/user-guide/aroma/sd-preparation.md
@@ -2,7 +2,7 @@
 
 ## SD Preparation
 
-We will now place the required CFW files and some additional homebrew files on the SD Card.
+We will now place the required Aroma files on the SD Card.
 
 ?> **Notice**
     Your SD Card will need to be formatted as FAT32. If your SD Card is not formatted to FAT32, use [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) with 32k (32768) allocation unit size to format it.  

--- a/docs/user-guide/aroma/sidebar.md
+++ b/docs/user-guide/aroma/sidebar.md
@@ -1,0 +1,11 @@
+- **Aroma**
+- [Home Page](../introduction)
+- [Getting Started with Aroma](getting-started)
+- [SD Preparation](sd-preparation)
+- [Finalizing Setup](finalizing-setup)
+- **Links**
+- [![GitHub](https://icongr.am/simple/github.svg?color=808080&size=16)GitHub](https://github.com/hacks-guide/Guide-WiiU)
+- [![Discord](https://icongr.am/simple/discord.svg?colored&size=16)Discord](https://discord.gg/C29hYvh)
+- [![Translate](https://icongr.am/material/translate.svg?color=808080&size=16)Translate](https://hacks-guide.crowdin.com/u/projects/10)
+- [Donate](../donations)
+- [About](../about)

--- a/docs/user-guide/tiramisu/finalizing-setup.md
+++ b/docs/user-guide/tiramisu/finalizing-setup.md
@@ -42,3 +42,9 @@ If you get a red warning screen while booting into Tiramisu, the update folder s
    Copy the `30_bloopair.rpx` to the `wiiu/environments/tiramisu/modules/setup/` folder on the root of your SD Card.  
    Copy the `wiiu` folder to the root of your SD Card.
 1. Copy the contents of the newly downloaded `wiiu-extracttosd.zip` file to the root of your SD Card.
+
+### Installing Aroma
+Aroma is a work-in-progress environment with support for plugins, modules and homebrew bundles.  
+Aroma can be installed additionally to Tiramisu, if you want to try out any of its features.
+
+[**The Aroma guide can be found here**](../aroma/getting-started)

--- a/index.html
+++ b/index.html
@@ -45,6 +45,11 @@
                 '/tiramisu/installing-payloadloader'                  : '/docs/user-guide/tiramisu/installing-payloadloader.md',
                 '/tiramisu/autobooting'                               : '/docs/user-guide/tiramisu/autoboot.md',
                 '/tiramisu/finalizing-setup'                          : '/docs/user-guide/tiramisu/finalizing-setup.md',
+                // Aroma
+                '/aroma/sidebar.md'                                   : '/docs/user-guide/aroma/sidebar.md',
+                '/aroma/getting-started'                              : '/docs/user-guide/aroma/getting-started.md',
+                '/aroma/sd-preparation'                               : '/docs/user-guide/aroma/sd-preparation.md',
+                '/aroma/finalizing-setup'                             : '/docs/user-guide/aroma/finalizing-setup.md',
                 // vWii
                 '/vwii-modding'                                       : '/docs/vwii/vwii-modding.md',
                 '/vwii/sidebar.md'                                    : '/docs/user-guide/vwii/sidebar.md',

--- a/index.html
+++ b/index.html
@@ -632,7 +632,7 @@
             },
             themeable    : {
                 readyTransition : true,
-                responsiveTables: true
+                responsiveTables: false
             },
             tabs: {
                 persist    : true,


### PR DESCRIPTION
Initial draft for an Aroma guide which can be followed after following the Tiramisu guide. A lot of the guide still relies on Tiramisu for now. 
The Aroma guide is also not available in the sidebar, but is linked at the end of the Tiramisu guide as an optional step.
The FAQ and troubleshooting pages have not been adjusted yet.

Ideally we should probably split up the Tiramisu guide into a generic PayloadLoader installation guide and make the concept of environments more clear.

A deployed version can be found [here](https://garyodernichts.github.io/Guide-WiiU/#/aroma/getting-started).