### PR TITLE
nand-backup.md: Describe resetting browser's data helps on stuck on white screen

### DIFF
--- a/docs/user-guide/tiramisu/nand-backup.md
+++ b/docs/user-guide/tiramisu/nand-backup.md
@@ -19,7 +19,7 @@ In case anything should go wrong in the later process and your Wii U ends up bri
     - Dump MLC: **optional**
     - Dump OTP: **yes**
     - Dump SEEPROM: **yes**
-1. Press the A button to start the dumping process.
+1. Press the A button to start the dumping process. The screen will become white for a few seconds until `nanddumper` kicks in and shows the progress. If it stays blank for a quite while, you may reset the console and retry it with [the browser's data reset](https://en-americas-support.nintendo.com/app/answers/detail/a_id/1507/~/how-to-delete-the-internet-browser-history).
 1. When the process completed, power off your Wii U, take your SD Card out of the Wii U and plug it into your PC.
 1. To make sure you don't lose the files, copy the `slc.bin`, `slccmpt.bin`, `seeprom.bin`, `otp.bin` and if you chose to go with a full backup, `every mlc.bin.part` file to your computer.
 1. Delete the files from your SD Card to free up space.


### PR DESCRIPTION
Credits to https://gist.github.com/fctsfrmspc/f029ab3fd6878002681502faccf91ada

While following the guide on how to make a NAND backup, after pressing A, my console stayed stuck on the white blank screen and did not transition to NAND dumper.
As the description of this guide was quite short, I didn't know if that was to expect or not and waited for a few minutes before starting to search for others having the same issue.
Discovering the post given above, I knew my console was stuck for good, reset it, cleared the browser's data and retried the dump, which then worked.

As others may see the same error, and especially because the guide didn't described what to expect (to me it feels realistic that a basic NAND dumper might not have an UI at all), I wanted to not only add a potential fix but also a description of what to expect so others might more easily recognize, that their console does not behave as expected.

Aside of that, thanks for that great guide. It worked well on my console.