### PR TITLE
Tiramisu SD Preparation: Cover versions.json

### DIFF
--- a/docs/user-guide/tiramisu/sd-preparation.md
+++ b/docs/user-guide/tiramisu/sd-preparation.md
@@ -70,6 +70,7 @@ We will now place the required CFW files and some additional homebrew files on t
    ┃   ┗ 📜payload.elf
    ┣ 📜payload.rpx
    ┗ 📜payload.elf
+ ┗ 📜versions.json
 ```
 
 </details>


### PR DESCRIPTION
Step 2 of the Instructions section asks to copy the Tiramisu .zip file's contents to the root of an SD card. But the SD Card Layout section lacked any mention the zip file's top-level versions.json file.

This adds versions.json to the end of the SD Card Layout's file tree.