### PR TITLE
Tiramisu is no longer needed to mod vWii

### DIFF
--- a/docs/user-guide/vwii/installing-homebrewchannel.md
+++ b/docs/user-guide/vwii/installing-homebrewchannel.md
@@ -2,8 +2,6 @@
 
 ## Installing the Homebrew Channel
 
-1. Boot into [Tiramisu](browser-exploit).
-1. Launch the Homebrew Launcher, by opening the Mii Maker.
 1. Launch the vWii Compat Installer.
 1. Press `A` to install the Homebrew Channel and wait until you see `Install succeeded`. Then press the HOME button to return to the Wii U Menu.
 1. Launch vWii (the Wii Menu icon).

--- a/docs/user-guide/vwii/sd-preparation.md
+++ b/docs/user-guide/vwii/sd-preparation.md
@@ -14,18 +14,14 @@ We will now start by placing the required Homebrew files on the SD Card.
 
 ### What You Need
 
-- The latest files from [Tiramisu for your café](https://tiramisu.foryour.cafe).
-    - Click on `Download Tiramisu`.
-    - If you have already installed Tiramisu, you do not need to redownload it.
 - The latest release of the [Compat Title Installer](https://hb-app.store/wiiu/CompatTitleInstaller).
-- The <a href="docs/files/Patched_IOS80_Installer_for_vWii.zip" download>Patched IOS 80 Installer for vWii</a>. ([Source](https://github.com/Lazr1026/Patched-IOS80-Installer-for-vWii))
 - The <a href ="docs/files/d2x_cIOS_Installer.zip" download>d2x cIOS Installer</a>.
+- The <a href="docs/files/Patched_IOS80_Installer_for_vWii.zip" download>Patched IOS 80 Installer for vWii</a>. ([Source](https://github.com/Lazr1026/Patched-IOS80-Installer-for-vWii))
 
 ## Instructions
 
 1. Insert your Wii U's SD Card into your PC.
-1. Copy the `apps` folder from the `Patched_IOS80_Installer_for_vWii.zip` file to the root of your SD Card.
-1. Copy the `d2x-cios-installer` from the `d2x_cIOS_Installer.zip` file to the apps folder on the root of your SD Card.
-1. Copy the contents of the downloaded Tiramisu *`.zip`* file to the root of your SD Card.
 1. Copy the contents of the `CompatTitleInstaller.zip` file to the root of your SD Card.
+1. Copy the `d2x-cios-installer` from the `d2x_cIOS_Installer.zip` file to the `apps` folder on the root of your SD Card.
+1. Copy the `apps` folder from the `Patched_IOS80_Installer_for_vWii.zip` file to the root of your SD Card.
 1. Take the SD Card out of your computer and plug it into your Wii U console.


### PR DESCRIPTION
vWii Compat Installer has a wuhb file now and can be executed directly from Aroma.

Downloading Tiramisu is unnecessary.