### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/extras/dump-wii-games.md
+++ b/docs/extras/dump-wii-games.md
@@ -2,7 +2,7 @@
 ---
 Dumping your Discs allows you to: play them on a Wii emulator (namely Dolphin), play them using a USB/SD Card loader such as Wiiflow, make Virtual Console injects that can be installed on a Wii U formatted USB drive or the NAND and launched from the Wii U Menu.
 
-?> Dumping Wii games requires a working homebrew setup on vWii, so make sure to finish the [vWii Modding guide](vwii-modding) beforehand.
+?> Dumping Wii games requires a working homebrew setup on vWii, so make sure to finish the [vWii Modding guide](vwii/sd-preparation) beforehand.
 
 !> It is **ILLEGAL** to share the files dumped with this guide.  
 If you intend to use this guide to share your dumped games, don't.

--- a/docs/troubleshooting/recover-vwii-ioses-channels.md
+++ b/docs/troubleshooting/recover-vwii-ioses-channels.md
@@ -46,7 +46,7 @@ This page will guide you through the process of recovering a IOS or channel on y
 
 </details>
 
-!> This has the potential to destroy your vWii NAND if you are not careful! Please consider [backing up](mocha/online-exploit/nand-backup) your SLCCMPT and OTP if you do not yet have them backed up!
+!> This has the potential to destroy your vWii NAND if you are not careful! Please consider [backing up](vwii/nand-backup) your SLCCMPT and OTP if you do not yet have them backed up!
 
 ?> If you are using a system update blocking method, please [remove it](unblock-updates).
 


### PR DESCRIPTION
Going through the documentation for vWii, I've run into a couple of broken links. You can see these below:

- The link in the first info callout on [Dumping Wii Discs](https://wiiu.hacks.guide/#/dump-wii-games)
- The link in the warning callout on [Recover a vWii IOS/Channel](https://wiiu.hacks.guide/#/recover-vwii-ioses-channels)

This PR updates those links to point to what I presume is the correct page.