### PR TITLE
index: add hack to restore docsify behaviour

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ hero:
   tagline: "A guide collaboration between Nintendo Homebrew's Helpers and Staff, from stock to Aroma custom firmware."
   image:
     src: "/assets/img/home-page-feature.jpg"
+
+head: [
+  ['script', {src: '/assets/js/docsify-wrapper.js'}]
+]
 ---
 
 ::: tip

--- a/docs/public/assets/js/docsify-wrapper.js
+++ b/docs/public/assets/js/docsify-wrapper.js
@@ -1,0 +1,27 @@
+/*
+    Copyright (C) 2024 Nintendo Homebrew
+
+    SPDX-License-Identifier: MIT
+*/
+
+const map = new WeakMap()
+
+function checkDocsify(callback) {
+    if (map.has(callback))
+        return;
+    map.set(callback, true);
+    if (document.readyState === 'complete')
+        callback();
+    else
+        window.addEventListener('load', callback, false);
+}
+
+checkDocsify(() => {
+    if(!window.location.hash)
+        return;
+
+    if(window.location.hash[1] == '/') {
+        path = window.location.hash.substring(1);
+        window.location.href = path;
+    }
+})


### PR DESCRIPTION
This attempts to restore the old behaviour of docsify.js, where it uses hash parameters to navigate the site. Since this isn't the case in VitePress, all the old links to the guide broke, so check it on load.

This works on a best-effort basis; if the corresponding page exists (such as `#/aroma/getting-started` -> `/aroma/getting-started`), it should navigate properly, but if the corresponding page doesn't exist, it will 404.