### PR TITLE
Replace SaveMii WUT Port with ProcessMod

### DIFF
--- a/docs/aroma/finalizing-setup.md
+++ b/docs/aroma/finalizing-setup.md
@@ -14,18 +14,18 @@ All Homebrew applications are loaded from the Wii U Menu on Aroma.
 
 :::
 
-- **SaveMii Mod WUT Port** is a homebrew app that lets you manage your Wii U and vWii save data.
+- **SaveMii ProcessMod** is a homebrew app that lets you manage your Wii U and vWii save data.
 - **Bloopair** is an Aroma module that lets you wirelessly connect most popular Bluetooth capable controllers. See [this page](https://gbatemp.net/threads/bloopair-connect-controllers-from-other-consoles-natively.594289/) for more details.
 - The **Homebrew Appstore** lets you browse and download homebrew apps directly from your Wii U.
 
 ### Additional Homebrew Apps - What You Need
 
-- The latest version of [SaveMii Mod WUT Port](https://wiiu.cdn.fortheusers.org/zips/SaveMiiModWUTPort.zip).
+- The latest version of [SaveMii ProcessMod](https://wiiu.cdn.fortheusers.org/zips/SaveMiiProcessMod.zip).
 - `wiiu-extracttosd.zip` of the [HB Appstore](https://github.com/fortheusers/hb-appstore/releases/).
 
 ### Additional Homebrew Apps - Extracting Files to the SD Card
 
-1. Copy the contents of the newly downloaded `SaveMiiModWUTPort.zip` file to the root of your SD Card.
+1. Copy the contents of the newly downloaded `SaveMiiProcessMod.zip` file to the root of your SD Card.
 1. Copy the contents of the newly downloaded `wiiu-extracttosd.zip` file to the root of your SD Card.
 
 ## Recommended Plugins


### PR DESCRIPTION
ProcessMod is an improvement over the original WUT port in many ways, including utilities not present in the older tool such as:

- Moving/copy files between profiles, perfect for setting up Pretendo accounts if you had a NNID account already
- Backup and restore Miis
- Backup and restore saves from system apps, like your account settings

It's also been proven to be stable and reliable, not to mention is also actively maintained while the older version won't receive updates in favour of this version anyway