### PR TITLE
Remove redundant section about "info.json" & "manifest.install"

### DIFF
--- a/docs/common-issues-fixes.md
+++ b/docs/common-issues-fixes.md
@@ -33,9 +33,6 @@ You can fix this by either using a powered HDD or using a Y-Cable to connect the
 
 If your HDD worked for some time and then stopped working for some games/all games, it is the same issue and can be fixed with the same methods.
 
-## When extracting some of the files there are duplicates of certain ones called "info.json" & "manifest.install", what do I do with those?
-
-Nothing special, you can leave them there, delete them or replace them with new ones. Those files are not used in the process, therefore, won't have any impact by being or not being there.
 
 ## My console suddenly lost online connectivity and I have an HDD sitting on top of the console, what should I do?
 


### PR DESCRIPTION
This specific question is in two pages: Common Issues & Fixes and the FAQ, this is redundant and only one page is enough. This fits better on the FAQ since this isn't really an issue users might have when modding the console.