### PR TITLE
Suggest against dumping MLC

### DIFF
--- a/docs/aroma/nand-backup.md
+++ b/docs/aroma/nand-backup.md
@@ -27,8 +27,8 @@ Your NAND Backup is unique to your system. Backups from other consoles **won't**
 
 1. Navigate to `nanddumper` using the GamePad and press A to launch it.
 1. Use the Wii U GamePad's D-Pad to enter the following configuration:
-    ![SLC: Yes, SLCCMPT: Yes, MLC: Yes or No, OTP: Yes, SEEPROM: Yes](/assets/img/guide/NAND.png)
-    - MLC is **OPTIONAL**, if you do not want to dump it, leave it on `No`. If you do want to dump it, make sure you have a SD Card big enough for it and put it on `Yes`.
+    ![SLC: Yes, SLCCMPT: yes, MLC: no, OTP: yes, SEEPROM: yes](/assets/img/guide/NAND.png)
+    - Do **NOT** dump the MLC at this stage to save time and space on your SD card. The dump produced here will have severely limited usefulness; if you want to dump your MLC, it's recommended to use [Dumpling](https://dumplingapp.com) to do so.
 1. Press the A button to start the dumping process.
 1. When the process is completed, power off your Wii U, take your SD Card out of the Wii U and plug it into your PC.
 1. To make sure you don't lose the files, copy the `slc.bin`, `slccmpt.bin`, `seeprom.bin`, `otp.bin` (and if you chose to go with a full backup, `every mlc.bin.part` file) to somewhere safe (Documents, Google Drive, OneDrive, etc.) on your computer.


### PR DESCRIPTION
The MLC dumping process using dimok's dumper comes with several drawbacks:
* most consoles, being 32GB units, will require a 64GB SD, which requires a bit more setup to make it functional with the Wii U;
* the dump produced is encrypted + uncompressed, wasting space;
* there is no way to use the raw dump as-is, since there is no procedure to restore the MLC by each bit; moreover, the dump will be locked to the SCFM at that point in time;
* compared to dumpling, reading effective "zero"/filler bytes wastes time.

Resolves issue #284.

Formatting; proper references to Dumpling; and other miscellaneous items to be confirmed.